### PR TITLE
Support string id of project

### DIFF
--- a/inputs/gitlab/gitlab.py
+++ b/inputs/gitlab/gitlab.py
@@ -9,6 +9,7 @@ gitlab_url = ""
 def parse():
     messages = []
     for repository_id in repositories:
+        repository_id = url_encoding(repository_id)
         response = urllib2.urlopen(gitlab_url + "api/v4/projects/"
                                    + repository_id
                                    + "/merge_requests?state=opened&private_token="
@@ -23,6 +24,10 @@ def parse():
                 messages.append(author_name + " wait while '" + mr_title
                                 + "' will be reviewed. You can open it by link: " + mr_url)
     return messages
+
+
+def url_encoding(repository_id):
+    return repository_id.replace("/", "%2F")
 
 
 def input():


### PR DESCRIPTION
Support string (example: "group/project") id of project instead of integer id (example: 42)